### PR TITLE
exact posting time now viewable by hovering

### DIFF
--- a/public/js/w0bmscript.js
+++ b/public/js/w0bmscript.js
@@ -311,6 +311,12 @@ function flash(type, message) {
         $("#toggle").click(function(){$(".comments").fadeToggle(localStorage.comments = !(localStorage.comments == "true"))});
     })();
 
+    $('a').on('click', function(e) {
+        if($(this).attr('href') == '#') {
+            e.preventDefault();
+        }
+    });
+
     /*
     COPYRIGHT © 2016 | jkhsjdhjs | moeller.mx
 

--- a/resources/views/partials/comment.blade.php
+++ b/resources/views/partials/comment.blade.php
@@ -2,7 +2,7 @@
     <div class="panel-body">
        @simplemd($comment->content)
     </div>
-    <div class="panel-footer">by <a href="/user/{{$comment->user->username}}">{{$comment->user->username}}</a> <small>{{$comment->created_at->diffForHumans()}}</small>
+    <div class="panel-footer">by <a href="/user/{{$comment->user->username}}">{{$comment->user->username}}</a> <small><a style="color: #888;" href="#" title="{{$comment->created_at->format('d.m.Y H:i')}}">{{$comment->created_at->diffForHumans()}}</a></small>
         @if($mod)
            @if($del)
                 <a href="{{url('comment/' . $comment->id . '/restore')}}" class=""><i style="color:green"; class="fa fa-refresh" aria-hidden="true"></i></a>

--- a/resources/views/video.blade.php
+++ b/resources/views/video.blade.php
@@ -65,7 +65,7 @@
 											@if($video->imgsource) <em>Video Source:</em> {{$video->imgsource}}<br>
 											@endif
 											<em>Category:</em> {{$video->category->name}}"></i>
-						uploaded by <i style="color: rgb(233, 233, 233);"><a href="{{ url('user/' . $video->user->username) }}">{{ $video->user->username }}@if($video->user->is('Moderator')) <i class="fa fa-bolt anim"></i>@endif</a></i>&nbsp {{ $video->created_at->diffForHumans() }}@if(auth()->check() && auth()->user()->can('delete_video')) <a data-confirm="Do you really want to delete this video?" class="" href="{{url($video->id . '/delete')}}"><i style="color:red;" class="fa fa-times" aria-hidden="true"></i></a>@endif @if(auth()->check() && auth()->user()->can('edit_video'))<a href="#" data-toggle="modal" data-target="#webmeditmodal"><i style="color:#2ada19;" class="fa fa-pencil-square"></i></a>@endif
+						uploaded by <i style="color: rgb(233, 233, 233);"><a href="{{ url('user/' . $video->user->username) }}">{{ $video->user->username }}@if($video->user->is('Moderator')) <i class="fa fa-bolt anim"></i>@endif</a></i>&nbsp <a style="color: #1FB2B0;" href="#" title="{{$video->created_at->format('d.m.Y H:i')}}">{{ $video->created_at->diffForHumans() }}</a>@if(auth()->check() && auth()->user()->can('delete_video')) <a data-confirm="Do you really want to delete this video?" class="" href="{{url($video->id . '/delete')}}"><i style="color:red;" class="fa fa-times" aria-hidden="true"></i></a>@endif @if(auth()->check() && auth()->user()->can('edit_video'))<a href="#" data-toggle="modal" data-target="#webmeditmodal"><i style="color:#2ada19;" class="fa fa-pencil-square"></i></a>@endif
 				</span>
 			</div>
 		</div>


### PR DESCRIPTION
- exact posting time of comments/videos is now viewable by hovering over the posting time
- because of this links with attr(href) == # won't be followed on click
