### PR TITLE
changes format of time when displaying hours

### DIFF
--- a/public/js/w0bmscript.js
+++ b/public/js/w0bmscript.js
@@ -495,6 +495,7 @@ $(function () {
     str.seconds = "%d seconds";
     str.minute = "1 minute";
     str.hour = "1 hour";
+    str.hours = "%d hours";
     str.day = "1 day";
     str.month = "1 month";
     str.year = "1 year";


### PR DESCRIPTION
now timeago is completely in laravel's diffForHumans() format

timeago applies 1 seconds after page load sometimes, now user won't notice when timeago starts running
