### PR TITLE
hides video player controls after 250ms inactivity

### DIFF
--- a/public/js/w0bmscript.js
+++ b/public/js/w0bmscript.js
@@ -17,7 +17,8 @@ var video = document.getElementById('video');
 if(video !== null) {
     var player = videojs(video, {
         controls: true,
-        playbackRates: [0.25, 0.5, 1, 1.5, 2]
+        playbackRates: [0.25, 0.5, 1, 1.5, 2],
+        inactivityTimeout: 250
     }, function() {
         this.addClass('video-js');
         this.volume(0.3);


### PR DESCRIPTION
hides video player controls after 250ms of inactivity instead of 2s (default)
